### PR TITLE
Add rest app for online inference

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install dependencies ml_project
         working-directory: ./ml_project
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements/tests.txt
 
-      - name: Lint
+      - name: Lint ml_project
         working-directory: ./ml_project
         run: |
           black --check .
           isort -c .
           flake8 .
           mypy clfit
+
+      - name: Lint online_inference
+        working-directory: ./online_inference
+        run: |
+          black --check .
+          isort -c .
+          flake8 .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,9 +67,9 @@ jobs:
         working-directory: ./online_inference
         run: |
           python -m pip install -r requirements.txt
+          wget https://github.com/made-ml-in-prod-2021/kbrodt/releases/download/v0.1/model.pkl
 
       - name: Test online_inference
         working-directory: ./online_inference
         run: |
-          wget https://github.com/made-ml-in-prod-2021/kbrodt/releases/download/v0.1/model.pkl
           PATH_TO_MODEL=model.pkl pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install dependencies ml_project
         working-directory: ./ml_project
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[all]
 
-      - name: Test
+      - name: Test ml_project
         working-directory: ./ml_project
         run: |
           python -m pytest . -v --cov
+
+      - name: Install dependencies online_inference
+        working-directory: ./online_inference
+        run: |
+          python -m pip install -r requirements.txt
+
+      - name: Test online_inference
+        working-directory: ./online_inference
+        run: |
+          wget https://github.com/made-ml-in-prod-2021/kbrodt/releases/download/v0.1/model.pkl
+          PATH_TO_MODEL=model.pkl pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,12 +64,14 @@ jobs:
           python -m pytest . -v --cov
 
       - name: Install dependencies online_inference
+        if: startsWith(matrix.os, 'windows') != true
         working-directory: ./online_inference
         run: |
           python -m pip install -r requirements.txt
           wget https://github.com/made-ml-in-prod-2021/kbrodt/releases/download/v0.1/model.pkl
 
       - name: Test online_inference
+        if: startsWith(matrix.os, 'windows') != true
         working-directory: ./online_inference
         run: |
           PATH_TO_MODEL=model.pkl pytest -v

--- a/online_inference/.flake8
+++ b/online_inference/.flake8
@@ -1,0 +1,47 @@
+[flake8]
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/README.md#line-length for more details
+max-line-length = 88
+max-complexity = 18
+# it's not a bug that we aren't using all of hacking
+extend-ignore =
+    E203,
+	# E501: line too long
+	E501,
+    # F812: list comprehension redefines ...
+    # F812,
+    # H101: Use TODO(NAME)
+    # H101,
+    # H202: assertRaises Exception too broad
+    # H202,
+    # H233: Python 3.x incompatible use of print operator
+    # H233,
+    # H301: one import per line
+    # H301,
+    # H306: imports not in alphabetical order (time, os)
+    # H306,
+    # H401: docstring should not start with a space
+    # H401,
+    # H403: multi line docstrings should end on a new line
+    # H403,
+    # H404: multi line docstring should start without a leading new line
+    # H404,
+    # H405: multi line docstring summary not separated with an empty line
+    # H405,
+    # H501: Do not use self.__dict__ for string formatting
+    # H501
+	# W503: line breake before binary operator
+	W503
+exclude =
+    # No need to traverse our git directory
+    .git,
+    # There's no value in checking cache directories
+    __pycache__,
+    # This contains our built documentation
+    build,
+    # This contains builds of flake8 that we don't want to check
+    dist
+# We need to configure the mypy.ini because the flake8-mypy's default
+# options don't properly override it, so if we don't specify it we get
+# half of the config from mypy.ini and half from flake8-mypy.
+mypy_config = ~/.config/mypy/config

--- a/online_inference/Dockerfile
+++ b/online_inference/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.9-slim-buster
+
+ENV VIRTUAL_ENV "/venv"
+ENV PATH "$VIRTUAL_ENV/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m venv $VIRTUAL_ENV \
+    && pip install --no-cache-dir "git+https://github.com/made-ml-in-prod-2021/kbrodt@homework1#egg=clfit&subdirectory=ml_project" \
+    && pip install --no-cache-dir fastapi uvicorn \
+    && mkdir /app
+
+COPY app.py \
+    config.py \
+    model.pkl \
+    /app/
+
+WORKDIR /app
+
+ENV PATH_TO_MODEL="model.pkl"
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/online_inference/README.md
+++ b/online_inference/README.md
@@ -1,0 +1,88 @@
+# ML in prod: Homework 2
+
+## Preresquistes
+
+First follow `ml_project` to download data and train models. Then put them into this folder.
+
+Build docker
+
+```bash
+docker build -t kbrodt/online_inference:v1 .
+```
+
+or pull
+
+```bash
+docker pull kbrodt/online_inference:v1
+```
+
+To make requests install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Testing
+
+```bash
+PATH_TO_MODEL=model.pkl pytest -v
+```
+
+## Usage
+
+Run docker
+
+```bash
+docker run --rm -p 8000:8000 kbrodt/online_inference:v1
+
+# or without docker
+PATH_TO_MODEL=model.pkl uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+and make requests
+
+```bash
+python make_request.py --host "localhost" --port "8000" --data-path "../ml_project/data/raw/heart.csv"
+```
+
+## Optimization
+
+First I tried lightweight `Alpine` but python packages installation is [very slow](https://pythonspeed.com/articles/alpine-docker-python/).
+So I moved to `python:3.9` (`886MB`), but quickly realised that `slim` version is better.
+
+1. `python:3.9-slim-buster` (`115MB`)
+2. Compose all commands into one in `RUN` and `COPY` layers
+3. Install only necessary python packages
+
+Final disk usage is `559MB`.
+
+Of course we can tweak images by removing all unused libraries and packages.
+
+## Usefull links
+
+* [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+* [best Docker base image for Python](https://pythonspeed.com/articles/base-image-python-docker-images/)
+* [pip install from git repo branch](https://stackoverflow.com/questions/20101834/pip-install-from-git-repo-branch)
+* [pip install frin git subdirectory](https://stackoverflow.com/questions/13566200/how-can-i-install-from-a-git-subdirectory-with-pip)
+
+## Roadmap
+
+- [X] ветку назовите homework2, положите код в папку online_inference
+- [X] Оберните inference вашей модели в rest сервис(вы можете использовать как FastAPI,
+  так и flask, другие желательно не использовать, дабы не плодить излишнего разнообразия для проверяющих),
+  должен быть endpoint /predict (3 балла)
+- [X] Напишите тест для /predict  (3 балла) (https://fastapi.tiangolo.com/tutorial/testing/, https://flask.palletsprojects.com/en/1.1.x/testing/)
+- [X] Напишите скрипт, который будет делать запросы к вашему сервису -- 2 балла
+- [X] Сделайте валидацию входных данных (например, порядок колонок не совпадает с трейном,
+  типы не те и пр, в рамках вашей фантазии)
+  (вы можете сохранить вместе с моделью доп информацию, о структуре входных данных, если это нужно) -- 3 доп балла
+  https://fastapi.tiangolo.com/tutorial/handling-errors/ -- возращайте 400, в случае, если валидация не пройдена
+- [X] Напишите dockerfile, соберите на его основе образ и запустите локально контейнер(docker build, docker run),
+  внутри контейнера должен запускать сервис, написанный в предущем пункте, закоммитьте его, напишите в readme корректную команду сборки (4 балл)
+- [X] Оптимизируйте размер docker image (3 доп балла)
+  (опишите в readme.md что вы предприняли для сокращения размера и каких результатов удалось добиться)  -- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+- [X] опубликуйте образ в https://hub.docker.com/, используя docker push (вам потребуется зарегистрироваться) (2 балла)
+- [X] напишите в readme корректные команды docker pull/run, которые должны привести к тому,
+  что локально поднимется на inference ваша модель (1 балл)
+  - Убедитесь, что вы можете протыкать его скриптом из пункта 3
+- [X] проведите самооценку -- 1 доп балл

--- a/online_inference/README.md
+++ b/online_inference/README.md
@@ -3,6 +3,11 @@
 ## Preresquistes
 
 First follow `ml_project` to download data and train models. Then put them into this folder.
+Or you can download the model via
+
+```bash
+wget https://github.com/made-ml-in-prod-2021/kbrodt/releases/download/v0.1/model.pkl
+```
 
 Build docker
 

--- a/online_inference/app.py
+++ b/online_inference/app.py
@@ -6,9 +6,12 @@ import pandas as pd
 import uvicorn
 from clfit.apis import load_model, predict_model
 from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from sklearn.pipeline import Pipeline
 
-from config import ENTRY_POINT_MSG, ID_COL, HeartDisease, Patient
+from config import ENTRY_POINT_MSG, ID_COL, STATUS_CODE, HeartDisease, Patient
 
 logger = logging.getLogger(__name__)
 model: Optional[Pipeline] = None
@@ -27,6 +30,14 @@ def make_predict(
     ]
 
     return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=STATUS_CODE,
+        content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
+    )
 
 
 @app.get("/")

--- a/online_inference/app.py
+++ b/online_inference/app.py
@@ -1,0 +1,68 @@
+import logging
+import os
+from typing import List, Optional, Union
+
+import pandas as pd
+import uvicorn
+from clfit.apis import load_model, predict_model
+from fastapi import FastAPI
+from sklearn.pipeline import Pipeline
+
+from config import ENTRY_POINT_MSG, ID_COL, HeartDisease, Patient
+
+logger = logging.getLogger(__name__)
+model: Optional[Pipeline] = None
+app = FastAPI()
+
+
+def make_predict(
+    data: List[List[Union[float, int]]], features: List[str], model: Pipeline
+) -> List[HeartDisease]:
+    df = pd.DataFrame(data, columns=features)
+    predicts = predict_model(model, df.drop(ID_COL, axis=1), return_proba=True)
+
+    response = [
+        HeartDisease(id=index, probability=proba)
+        for index, proba in zip(df[ID_COL].values, predicts)
+    ]
+
+    return response
+
+
+@app.get("/")
+def main():
+    return ENTRY_POINT_MSG
+
+
+@app.on_event("startup")
+def prepare_model():
+    global model
+
+    model_path = os.getenv("PATH_TO_MODEL")
+    logger.info("load model from %s", model_path)
+
+    if model_path is None:
+        err = f"PATH_TO_MODEL {model_path} is None"
+        logger.error(err)
+
+        raise RuntimeError(err)
+
+    model = load_model(model_path)
+
+
+@app.get("/health")
+def health() -> bool:
+    return not (model is None)
+
+
+@app.get("/predict", response_model=List[HeartDisease])
+def predict(request: Patient):
+    assert model is not None
+
+    response = make_predict(request.data, request.features, model)
+
+    return response
+
+
+if __name__ == "__main__":
+    uvicorn.run("app:app", host="0.0.0.0", port=os.getenv("PORT", 8000))

--- a/online_inference/config.py
+++ b/online_inference/config.py
@@ -23,6 +23,7 @@ FEATURES_MINMAX_VALS = [
 FEATURES = [f for f, _ in FEATURES_MINMAX_VALS]
 N_FEATURES = len(FEATURES)
 
+STATUS_CODE = 400
 ENTRY_POINT_MSG = "It is heart desease predictor"
 CAT_OUT_OF_RANGE_ERR = "Categorical value is out of range"
 INCORRECT_FEATURES_ERR = "Incorrect features order/columns"

--- a/online_inference/config.py
+++ b/online_inference/config.py
@@ -1,0 +1,61 @@
+from typing import Union
+
+from pydantic import BaseModel, conlist, validator
+
+# This is done based on EDA during ml_project step
+ID_COL = "Id"
+FEATURES_MINMAX_VALS = [
+    (ID_COL, None),
+    ("age", None),
+    ("sex", [0, 1]),
+    ("cp", [0, 3]),
+    ("trestbps", None),
+    ("chol", None),
+    ("fbs", [0, 1]),
+    ("restecg", [0, 2]),
+    ("thalach", None),
+    ("exang", [0, 1]),
+    ("oldpeak", None),
+    ("slope", [0, 2]),
+    ("ca", [0, 4]),
+    ("thal", [0, 3]),
+]
+FEATURES = [f for f, _ in FEATURES_MINMAX_VALS]
+N_FEATURES = len(FEATURES)
+
+ENTRY_POINT_MSG = "It is heart desease predictor"
+CAT_OUT_OF_RANGE_ERR = "Categorical value is out of range"
+INCORRECT_FEATURES_ERR = "Incorrect features order/columns"
+
+
+class Patient(BaseModel):
+    data: conlist(
+        conlist(Union[float, int], min_items=N_FEATURES, max_items=N_FEATURES),
+        min_items=1,
+    )
+    features: conlist(str, min_items=N_FEATURES, max_items=N_FEATURES)
+
+    @validator("data")
+    def data_consistency(cls, data):
+        for sample in data:
+            for value, (_, min_max) in zip(sample, FEATURES_MINMAX_VALS):
+                if min_max is None:
+                    continue
+
+                min_value, max_value = min_max
+                if not (min_value <= value <= max_value):
+                    raise ValueError(CAT_OUT_OF_RANGE_ERR)
+
+        return data
+
+    @validator("features")
+    def feature_consistency(cls, features):
+        if features != FEATURES:
+            raise ValueError(INCORRECT_FEATURES_ERR)
+
+        return features
+
+
+class HeartDisease(BaseModel):
+    id: int
+    probability: float

--- a/online_inference/make_request.py
+++ b/online_inference/make_request.py
@@ -1,0 +1,71 @@
+import argparse
+import logging
+
+import numpy as np
+import requests
+from clfit.data import read_data
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 8000
+DEFAULT_DATA_PATH = "heart.csv"
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        required=False,
+        default=DEFAULT_DATA_PATH,
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        required=False,
+        default=DEFAULT_HOST,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        required=False,
+        default=DEFAULT_PORT,
+    )
+
+    arguments = parser.parse_args()
+
+    return arguments
+
+
+def main():
+    arguments = parse_args()
+
+    df = read_data(arguments.data_path)
+    df.drop("target", inplace=True, axis=1)
+
+    features = ["Id"]
+    features.extend(df.columns)
+
+    logger.info("request features %s", features)
+    for row in df.itertuples():
+        data = [x.item() if isinstance(x, np.generic) else x for x in row]
+        logger.info("requests %s", data)
+
+        request = {"data": [data], "features": features}
+        response = requests.get(
+            f"http://{arguments.host}:{arguments.port}/predict/",
+            json=request,
+        )
+
+        logger.info("resonse status code %s", response.status_code)
+        logger.info("resonse %s", response.json())
+
+
+if __name__ == "__main__":
+    main()

--- a/online_inference/predict_test.py
+++ b/online_inference/predict_test.py
@@ -1,11 +1,17 @@
 import random
 
 import pytest
-from app import app
 from fastapi.testclient import TestClient
 
-from config import (CAT_OUT_OF_RANGE_ERR, FEATURES, FEATURES_MINMAX_VALS,
-                    INCORRECT_FEATURES_ERR, N_FEATURES)
+from app import app
+from config import (
+    CAT_OUT_OF_RANGE_ERR,
+    FEATURES,
+    FEATURES_MINMAX_VALS,
+    INCORRECT_FEATURES_ERR,
+    N_FEATURES,
+    STATUS_CODE,
+)
 
 N_SAMPLES = 10
 
@@ -134,7 +140,7 @@ def test_prediction_without_data(no_data):
         response = client.get("/predict/", json=no_data)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert (
             response_json["detail"][0]["msg"]
             == "ensure this value has at least 1 items"
@@ -147,7 +153,7 @@ def test_prediction_bad_types(data_bad_types):
         response_json = response.json()
 
         assert len(response_json["detail"]) == 2 * N_SAMPLES * N_FEATURES
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert all(
             item["msg"] == "value is not a valid float"
             for item in response_json["detail"][::2]
@@ -172,7 +178,7 @@ def test_prediction_with_categorical_values_out_of_range(data_with_cat_vals_oor)
         response = client.get("/predict/", json=data_with_cat_vals_oor)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == 1
         assert all(
             item["msg"] == CAT_OUT_OF_RANGE_ERR for item in response_json["detail"]
@@ -184,7 +190,7 @@ def test_prediction_incorrect_order(data_bad_order):
         response = client.get("/predict/", json=data_bad_order)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == 1
         assert all(
             item["msg"] == INCORRECT_FEATURES_ERR for item in response_json["detail"]
@@ -196,7 +202,7 @@ def test_prediction_incorrect_data_without_one_column(data_without_one_column):
         response = client.get("/predict/", json=data_without_one_column)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES
         assert all(
             item["msg"] == f"ensure this value has at least {N_FEATURES} items"
@@ -209,7 +215,7 @@ def test_prediction_incorrect_data_with_extra_columns(data_with_extra_columns):
         response = client.get("/predict/", json=data_with_extra_columns)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES
         assert all(
             item["msg"] == f"ensure this value has at most {N_FEATURES} items"
@@ -222,7 +228,7 @@ def test_prediction_incorrect_features_without_one_columns(features_without_one_
         response = client.get("/predict/", json=features_without_one_column)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == 1
         assert all(
             item["msg"] == f"ensure this value has at least {N_FEATURES} items"
@@ -235,7 +241,7 @@ def test_prediction_incorrect_features_with_extra_columns(features_with_extra_co
         response = client.get("/predict/", json=features_with_extra_columns)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == 1
         assert all(
             item["msg"] == f"ensure this value has at most {N_FEATURES} items"
@@ -250,7 +256,7 @@ def test_prediction_incorrect_data_features_without_one_columns(
         response = client.get("/predict/", json=data_features_without_one_column)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES + 1
         assert all(
             item["msg"] == f"ensure this value has at least {N_FEATURES} items"
@@ -265,7 +271,7 @@ def test_prediction_incorrect_data_features_with_extra_columns(
         response = client.get("/predict/", json=data_features_with_extra_columns)
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES + 1
         assert all(
             item["msg"] == f"ensure this value has at most {N_FEATURES} items"
@@ -282,7 +288,7 @@ def test_prediction_incorrect_data_without_one_columns_features_with(
         )
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES + 1
         assert all(
             item["msg"] == f"ensure this value has at least {N_FEATURES} items"
@@ -303,7 +309,7 @@ def test_prediction_incorrect_data_with_extra_columns_features_without(
         )
         response_json = response.json()
 
-        assert response.status_code == 422
+        assert response.status_code == STATUS_CODE
         assert len(response_json["detail"]) == N_SAMPLES + 1
         assert all(
             item["msg"] == f"ensure this value has at most {N_FEATURES} items"

--- a/online_inference/predict_test.py
+++ b/online_inference/predict_test.py
@@ -1,0 +1,315 @@
+import random
+
+import pytest
+from app import app
+from fastapi.testclient import TestClient
+
+from config import (CAT_OUT_OF_RANGE_ERR, FEATURES, FEATURES_MINMAX_VALS,
+                    INCORRECT_FEATURES_ERR, N_FEATURES)
+
+N_SAMPLES = 10
+
+
+def make_request(data, features):
+    return {
+        "data": data,
+        "features": features,
+    }
+
+
+@pytest.fixture
+def no_data():
+    samples = []
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def data():
+    samples = [
+        [
+            random.randint(*min_max) if min_max is not None else random.random()
+            for _, min_max in FEATURES_MINMAX_VALS
+        ]
+        for _ in range(N_SAMPLES)
+    ]
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def data_bad_types():
+    samples = [["kek"] * N_FEATURES] * N_SAMPLES
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def data_with_cat_vals_oor():
+    samples = [
+        [
+            random.randint(*min_max) + max(min_max) + 1
+            if min_max is not None
+            else random.random()
+            for _, min_max in FEATURES_MINMAX_VALS
+        ]
+        for _ in range(N_SAMPLES)
+    ]
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def data_bad_order(data):
+    samples = data["data"]
+    samples = [sample for sample in samples]
+
+    return make_request(samples, FEATURES[::-1])
+
+
+@pytest.fixture
+def data_without_one_column(data):
+    samples = data["data"]
+    samples = [sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def data_with_extra_columns(data):
+    samples = data["data"]
+    samples = [sample + sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES)
+
+
+@pytest.fixture
+def features_without_one_column(data):
+    samples = data["data"]
+
+    return make_request(samples, FEATURES[1:])
+
+
+@pytest.fixture
+def features_with_extra_columns(data):
+    samples = data["data"]
+
+    return make_request(samples, FEATURES + FEATURES[1:])
+
+
+@pytest.fixture
+def data_features_without_one_column(data):
+    samples = data["data"]
+    samples = [sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES[1:])
+
+
+@pytest.fixture
+def data_features_with_extra_columns(data):
+    samples = data["data"]
+    samples = [sample + sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES + FEATURES[1:])
+
+
+@pytest.fixture
+def data_without_one_column_features_with_extra_one(data):
+    samples = data["data"]
+    samples = [sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES + FEATURES[1:])
+
+
+@pytest.fixture
+def data_with_extra_columns_features_without(data):
+    samples = data["data"]
+    samples = [sample + sample[1:] for sample in samples]
+
+    return make_request(samples, FEATURES[1:])
+
+
+def test_prediction_without_data(no_data):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=no_data)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert (
+            response_json["detail"][0]["msg"]
+            == "ensure this value has at least 1 items"
+        )
+
+
+def test_prediction_bad_types(data_bad_types):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_bad_types)
+        response_json = response.json()
+
+        assert len(response_json["detail"]) == 2 * N_SAMPLES * N_FEATURES
+        assert response.status_code == 422
+        assert all(
+            item["msg"] == "value is not a valid float"
+            for item in response_json["detail"][::2]
+        )
+        assert all(
+            item["msg"] == "value is not a valid integer"
+            for item in response_json["detail"][1::2]
+        )
+
+
+def test_prediction(data):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data)
+        response_json = response.json()
+
+        assert response.status_code == 200
+        assert len(response_json) == N_SAMPLES
+
+
+def test_prediction_with_categorical_values_out_of_range(data_with_cat_vals_oor):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_with_cat_vals_oor)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == 1
+        assert all(
+            item["msg"] == CAT_OUT_OF_RANGE_ERR for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_order(data_bad_order):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_bad_order)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == 1
+        assert all(
+            item["msg"] == INCORRECT_FEATURES_ERR for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_data_without_one_column(data_without_one_column):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_without_one_column)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES
+        assert all(
+            item["msg"] == f"ensure this value has at least {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_data_with_extra_columns(data_with_extra_columns):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_with_extra_columns)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES
+        assert all(
+            item["msg"] == f"ensure this value has at most {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_features_without_one_columns(features_without_one_column):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=features_without_one_column)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == 1
+        assert all(
+            item["msg"] == f"ensure this value has at least {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_features_with_extra_columns(features_with_extra_columns):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=features_with_extra_columns)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == 1
+        assert all(
+            item["msg"] == f"ensure this value has at most {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_data_features_without_one_columns(
+    data_features_without_one_column,
+):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_features_without_one_column)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES + 1
+        assert all(
+            item["msg"] == f"ensure this value has at least {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_data_features_with_extra_columns(
+    data_features_with_extra_columns,
+):
+    with TestClient(app) as client:
+        response = client.get("/predict/", json=data_features_with_extra_columns)
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES + 1
+        assert all(
+            item["msg"] == f"ensure this value has at most {N_FEATURES} items"
+            for item in response_json["detail"]
+        )
+
+
+def test_prediction_incorrect_data_without_one_columns_features_with(
+    data_without_one_column_features_with_extra_one,
+):
+    with TestClient(app) as client:
+        response = client.get(
+            "/predict/", json=data_without_one_column_features_with_extra_one
+        )
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES + 1
+        assert all(
+            item["msg"] == f"ensure this value has at least {N_FEATURES} items"
+            for item in response_json["detail"][:-1]
+        )
+        assert (
+            response_json["detail"][-1]["msg"]
+            == f"ensure this value has at most {N_FEATURES} items"
+        )
+
+
+def test_prediction_incorrect_data_with_extra_columns_features_without(
+    data_with_extra_columns_features_without,
+):
+    with TestClient(app) as client:
+        response = client.get(
+            "/predict/", json=data_with_extra_columns_features_without
+        )
+        response_json = response.json()
+
+        assert response.status_code == 422
+        assert len(response_json["detail"]) == N_SAMPLES + 1
+        assert all(
+            item["msg"] == f"ensure this value has at most {N_FEATURES} items"
+            for item in response_json["detail"][:-1]
+        )
+        assert (
+            response_json["detail"][-1]["msg"]
+            == f"ensure this value has at least {N_FEATURES} items"
+        )

--- a/online_inference/pyproject.toml
+++ b/online_inference/pyproject.toml
@@ -1,0 +1,65 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+
+[tool.isort]
+profile = "hug"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88
+
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = ["C0330", "C0326"]
+
+[tool.pylint.format]
+max-line-length = 88
+
+
+[tool.coverage.run]
+branch = true
+source = ["."]
+omit = ["*/.tox/*", "*/__main__.py", "*/venv*/*", "*/setup.py"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+fail_under = 80
+exclude_lines = [
+    # a more strict default pragma
+    "\\# pragma: no cover\\b",
+
+    # allow defensive code
+    "^\\s*raise AssertionError\\b",
+    "^\\s*raise NotImplementedError\\b",
+    "^\\s*return NotImplemented\\b",
+    "^\\s*raise$",
+
+    # typing-related code
+    "^if (False|TYPE_CHECKING):",
+    ": \\.\\.\\.$",
+    "^ +\\.\\.\\.$",
+    "-> ['\"]?NoReturn['\"]?:",
+
+    # non-runnable code
+    "if __name__ == ['\"]__main__['\"]:$",
+]

--- a/online_inference/requirements.txt
+++ b/online_inference/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+pytest
+requests
+uvicorn


### PR DESCRIPTION
Сделаны все пункты из дз.

Инференс обёрнут в фастапи. Написано много тестов для провекри корректности входных данных для предикта. Есть скрипт, который делает запросы. Для всего этого есть докер, который можно собрать как локально, так и спулить. В качестве оптимизаци использоволся легковесный докер образ `python:3.9-slim-buster` (115Mb против 886Mb `python:3.9`). Также скомпоновал все команды в рамках одного слоя `RUN` и `COPY`. Была попытка собрать свой образ с нуля на базе `Alpine`,  но оказалось, что питоновские пакеты устанавливаются очень медленно.

Полный балл + бонусы за различные тесты и информацию, что докер на базе `Alpine` лучше не собирать, если нужно будет установть нампаи, склёрны и тд. За настроенные гитхаб события для теста приложения.